### PR TITLE
feat(permissions): Implementa controle de acesso baseado em grupos

### DIFF
--- a/passage/management/commands/setup_groups.py
+++ b/passage/management/commands/setup_groups.py
@@ -1,41 +1,53 @@
-from django.core.management.base import BaseCommand
 from django.contrib.auth.models import Group, Permission
-from django.core.exceptions import ObjectDoesNotExist
+from django.contrib.contenttypes.models import ContentType
+from django.core.management.base import BaseCommand
+from passage.models import Passage
+from ticket.models import Ticket
+
 
 class Command(BaseCommand):
-    help = 'Configura grupos e permissões iniciais'
+    help = 'Cria grupos de usuários e define suas permissões'
 
     def handle(self, *args, **options):
-        usuario_group, _ = Group.objects.get_or_create(name='Usuario')
-        proprietario_group, _ = Group.objects.get_or_create(name='Proprietario')
-        admin_group, _ = Group.objects.get_or_create(name='Administrador')
+        user_group, created = Group.objects.get_or_create(name='Usuario')
+        if created:
+            content_type_ticket = ContentType.objects.get_for_model(Ticket)
+            permission_add_ticket = Permission.objects.get(codename='add_ticket', content_type=content_type_ticket)
+            permission_view_ticket = Permission.objects.get(codename='view_ticket', content_type=content_type_ticket)
 
-        # Permissões para o grupo Usuario
-        try:
-            perms_usuario = [
-                'add_ticket', 'view_ticket',
-                'add_user', 'view_user', 'change_user', 'delete_user',
-                'view_passage',
-                'view_vessel',
-            ]
-            usuario_group.permissions.clear()
-            for codename in perms_usuario:
-                perm = Permission.objects.get(codename=codename)
-                usuario_group.permissions.add(perm)
-        except ObjectDoesNotExist as e:
-            self.stdout.write(self.style.WARNING(f'Permissão não encontrada: {e}'))
+            user_group.permissions.add(permission_add_ticket)
+            user_group.permissions.add(permission_view_ticket)
 
-        try:
-            perms_proprietario = [
-                'view_user', 'change_user', 'delete_user',
-                'add_vessel', 'view_vessel','change_vessel', 'delete_vessel',
-                'add_passage', 'view_passage', 'change_passage', 'delete_passage',
-            ]
-            proprietario_group.permissions.clear()
-            for codename in perms_proprietario:
-                perm = Permission.objects.get(codename=codename)
-                proprietario_group.permissions.add(perm)
-        except ObjectDoesNotExist as e:
-            self.stdout.write(self.style.WARNING(f'Permissão não encontrada: {e}'))
+            self.stdout.write(self.style.SUCCESS('Grupo "Usuario" criado e permissões de ticket adicionadas.'))
+        else:
+            self.stdout.write('Grupo "Usuario" já existe.')
 
-        self.stdout.write(self.style.SUCCESS('Grupos e permissões configurados.'))
+        proprietary_group, created = Group.objects.get_or_create(name='Proprietario')
+        if created:
+            content_type_passage = ContentType.objects.get_for_model(Passage)
+            permission_add_passage = Permission.objects.get(codename='add_passage', content_type=content_type_passage)
+            permission_change_passage = Permission.objects.get(codename='change_passage', content_type=content_type_passage)
+            permission_delete_passage = Permission.objects.get(codename='delete_passage', content_type=content_type_passage)
+            permission_view_passage = Permission.objects.get(codename='view_passage', content_type=content_type_passage)
+
+            proprietary_group.permissions.add(
+                permission_add_passage,
+                permission_change_passage,
+                permission_delete_passage,
+                permission_view_passage
+            )
+
+            self.stdout.write(self.style.SUCCESS('Grupo "Proprietario" criado e permissões de passagem adicionadas.'))
+        else:
+            self.stdout.write('Grupo "Proprietario" já existe.')
+
+        admin_group, created = Group.objects.get_or_create(name='Administrador')
+        if created:
+            self.stdout.write(self.style.SUCCESS('Grupo "Administrador" criado.'))
+        else:
+            self.stdout.write('Grupo "Administrador" já existe.')
+
+        all_permissions = Permission.objects.all()
+        admin_group.permissions.set(all_permissions)
+
+        self.stdout.write(self.style.SUCCESS('Todas as permissões foram concedidas ao grupo "Administrador".'))

--- a/passage/permissions.py
+++ b/passage/permissions.py
@@ -1,7 +1,6 @@
 from rest_framework.permissions import BasePermission, SAFE_METHODS
 
-
-class IsProprietaryOrReadOnly(BasePermission):
+class IsProprietarioOrReadOnly(BasePermission):
     def has_permission(self, request, view):
         if request.method in SAFE_METHODS:
             return True
@@ -13,5 +12,7 @@ class IsProprietaryOrReadOnly(BasePermission):
 
 class IsProprietary(BasePermission):
     def has_permission(self, request, view):
-        return request.user and request.user.is_authenticated and request.user.groups.filter(
-            name='Proprietario').exists()
+        return (request.user
+                and request.user.is_authenticated
+                and request.user.groups.filter(name="Proprietario").exists()
+                )

--- a/passage/viewsets.py
+++ b/passage/viewsets.py
@@ -2,9 +2,9 @@ from django_filters import rest_framework as filters
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets
 from rest_framework.generics import ListAPIView
-from rest_framework.permissions import BasePermission, SAFE_METHODS, AllowAny, IsAuthenticated
+from rest_framework.permissions import AllowAny, IsAdminUser
 from passage.models import Passage, City
-from user.permissions import IsUserReadOnly
+from .permissions import IsProprietarioOrReadOnly
 from .serializers import PassageSerializer, CitySerializer
 
 
@@ -17,30 +17,15 @@ class PassageFilter(DjangoFilterBackend):
         model = Passage
         fields = ['origin', 'destination', 'value']
 
-
-class ReadOnlyOrAuthenticated(BasePermission):
-    def has_permission(self, request, view):
-        if request.method in SAFE_METHODS:
-            return True
-        return request.user and request.user.is_authenticated
-
 class PassageViewSet(viewsets.ModelViewSet):
     queryset = Passage.objects.all()
     serializer_class = PassageSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ['origin', 'destination', 'travel_date', 'value']
-
-    def get_permissions(self):
-        user = self.request.user
-        if user.is_authenticated and user.groups.filter(name='Proprietario').exists():
-            return [IsAuthenticated()]
-        elif user.is_authenticated and user.groups.filter(name='Usuario').exists():
-            return [IsUserReadOnly()]
-        return [AllowAny()]
-
-
+    permission_classes = [IsProprietarioOrReadOnly | IsAdminUser]
 
 class CityListView(ListAPIView):
     queryset = City.objects.all()
     serializer_class = CitySerializer
     pagination_class = None
+    permission_classes = [AllowAny]

--- a/ticket/viewsets.py
+++ b/ticket/viewsets.py
@@ -1,12 +1,12 @@
 from rest_framework import viewsets
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from .models import Ticket
 from .serializers import TicketSerializer
 
 class TicketViewSet(viewsets.ModelViewSet):
     queryset = Ticket.objects.all()
     serializer_class = TicketSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated | IsAdminUser]
 
     def get_queryset(self):
         if self.request.user.is_authenticated:

--- a/user/permissions.py
+++ b/user/permissions.py
@@ -1,19 +1,5 @@
-from rest_framework.permissions import BasePermission, SAFE_METHODS
+from rest_framework.permissions import BasePermission
 
 class IsSelf(BasePermission):
     def has_object_permission(self, request, view, obj):
         return obj == request.user
-
-class IsUserReadOnly(BasePermission):
-    def has_permissions(self, request, view):
-        if request.method in SAFE_METHODS:
-            return (
-                request.user
-                and request.user.is_authenticated
-                and request.user.groups.filter(name='Usuario').exists()
-            )
-        return False
-
-
-
-

--- a/user/viewsets.py
+++ b/user/viewsets.py
@@ -1,22 +1,30 @@
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import OrderingFilter
-from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.viewsets import ModelViewSet
-from .models import User
-from .permissions import IsSelf
-from .serializers import UserSerializer
+from user.models import User
+from user.permissions import IsSelf
+from user.serializers import UserSerializer
 
 
 class UserViewSet(ModelViewSet):
     queryset = User.objects.all()
-    serializer_class = UserSerializer
     filter_backends = [DjangoFilterBackend, OrderingFilter]
     filterset_fields = ['name', 'username', 'email']
     ordering_fields = ['name', 'username', 'email']
+    serializer_class = UserSerializer
+
+    def get_queryset(self):
+        user = self.request.user
+        if user.is_authenticated:
+            return User.objects.filter(pk=user.pk)
+        return User.objects.none()
 
     def get_permissions(self):
         if self.action == 'create':
-            return [AllowAny()]
-        if self.action in ['retrieve', 'update', 'partial_update', 'destroy']:
-            return [IsAuthenticated(), IsSelf()]
-        return [IsAuthenticated()]
+            permission_classes = [AllowAny]
+        elif self.action in ['retrieve', 'update', 'partial_update', 'destroy']:
+            permission_classes = [IsAuthenticated, IsSelf]
+        else:
+            permission_classes = [IsAuthenticated]
+        return [permission() for permission in permission_classes]

--- a/vessel/viewsets.py
+++ b/vessel/viewsets.py
@@ -1,8 +1,9 @@
 from django_filters import rest_framework as filters
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets
-from rest_framework.permissions import AllowAny
-from passage.permissions import IsProprietary
+from rest_framework.permissions import IsAdminUser
+
+from passage.permissions import IsProprietarioOrReadOnly
 from vessel.models import Vessel
 from .serializers import VesselSerializer
 
@@ -17,14 +18,9 @@ class VesselFilter(filters.FilterSet):
         model = Vessel
         fields = ['name_vessel', 'name_owner', 'capacity', 'navigation_type']
 
-
 class VesselViewSet(viewsets.ModelViewSet):
     queryset = Vessel.objects.all()
     serializer_class = VesselSerializer
     filter_backends = [DjangoFilterBackend]
-    filterset_class =   VesselFilter
-
-    def get_permissions(self):
-        if self.action in ['list', 'retrieve']:
-            return [AllowAny()]
-        return [IsProprietary()]
+    filterset_class = VesselFilter
+    permission_classes = [IsProprietarioOrReadOnly | IsAdminUser]


### PR DESCRIPTION
### Grupos de Permissão

Foram criados três grupos principais que ditam as regras de acesso na aplicação:

- **Administrador:** Possui acesso total e irrestrito a todos os endpoints e funcionalidades da API. Este grupo tem todas as permissões do sistema e pode gerenciar qualquer dado.

- **Proprietario:** Representa os donos de embarcações. Usuários neste grupo têm permissão total (CRUD - Criar, Ler, Atualizar, Deletar) sobre os endpoints de `Vessel` (embarcações) e `Passage` (passagens), permitindo o gerenciamento completo de suas viagens.

- **Usuario:** É o grupo padrão para usuários registrados. Eles podem gerenciar seus próprios perfis, comprar `Tickets` e visualizar os seus roteiros (`TravelItinerary`). O acesso aos endpoints `Vessel` e `Passage` é somente de leitura (`GET`).

### Acesso para Pessoas Não Autenticadas

Para permitir que visitantes do site possam visualizar as viagens disponíveis antes de se cadastrarem, o seguinte acesso de leitura foi liberado:

- **Visualização de Passagens:** Qualquer pessoa (autenticada ou não) pode listar e ver os detalhes das passagens disponíveis através do método `GET` no endpoint `/api/passage/`.
- **Visualização de Embarcações:** Da mesma forma, a lista e os detalhes das embarcações podem ser consultados via `GET` em `/api/vessel/`.
- **Cadastro de Usuário:** O endpoint de criação de usuário (`POST /api/user/`) é público para permitir o registro de novas contas.